### PR TITLE
Simplify usage of [@Starter]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,12 +6,8 @@ copyright_year   = 2016
 
 version = 0.005
 
-[@Filter]
--bundle = @Starter
--remove = GatherDir
-
-[GatherDir]
-exclude_filename = README.md
+[@Starter]
+GatherDir.exclude_filename[0] = README.md
 
 [GithubMeta]
 


### PR DESCRIPTION
The ConfigSlicer role that @Starter uses means that you can configure included plugins directly. You also don't need @Filter in order to remove plugins thanks to the PluginRemover role. https://metacpan.org/pod/Dist::Zilla::PluginBundle::Starter#CONFIGURING has some more examples :)